### PR TITLE
Fixed resources' name find on reload

### DIFF
--- a/src/features/serverInteractions.ts
+++ b/src/features/serverInteractions.ts
@@ -152,7 +152,22 @@ export function restartResource(uri: vscode.Uri) {
         folderPath = path.dirname(uri.fsPath + "\\fakePath");
     else
         folderPath = path.dirname(uri.fsPath);
-    let resourceName = folderPath.substr(folderPath.lastIndexOf("\\") + 1, folderPath.length - folderPath.lastIndexOf("\\"));
+
+    let resourceName = folderPath.substr(folderPath.lastIndexOf("deathmatch\\resources"))
+        .split("\\")
+        .filter(
+            path => !path.includes("[") && 
+                    !path.includes("]") && 
+                    path !== "deathmatch" && 
+                    path !== "resources"
+        )[0];
+    
+    /* This means that either the user created a file in the ..\deathmatch\resources folder or 
+       some of its resources contain the directory deathmatch\resources in it */
+    if (!resourceName) {
+        vscode.window.showErrorMessage("Invalid resource structure");
+        return;
+    }
 
     searchResource(resourceName, (result, response, index, resourceName) => {
         if (!result) {

--- a/src/features/serverInteractions.ts
+++ b/src/features/serverInteractions.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as request from 'request';
 import { isArray } from 'util';
 import * as fs from 'fs';
+import { getResourceNameFromPath } from '../utils';
 
 export enum CallType {
     Start,
@@ -153,19 +154,10 @@ export function restartResource(uri: vscode.Uri) {
     else
         folderPath = path.dirname(uri.fsPath);
 
-    let resourceName = folderPath.substr(folderPath.lastIndexOf("deathmatch\\resources"))
-        .split("\\")
-        .filter(
-            path => !path.includes("[") && 
-                    !path.includes("]") && 
-                    path !== "deathmatch" && 
-                    path !== "resources"
-        )[0];
-    
-    /* This means that either the user created a file in the ..\deathmatch\resources folder or 
-       some of its resources contain the directory deathmatch\resources in it */
+    let resourceName = getResourceNameFromPath(folderPath);
+
     if (!resourceName) {
-        vscode.window.showErrorMessage("Invalid resource structure");
+        vscode.window.showErrorMessage("Could not find meta.xml");
         return;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,28 @@ export function getScriptSide(fileName: string): ScriptSide {
 
     return ScriptSide.Shared;
 }
+
+/**
+ * Determines the resource name based on the given path
+ *  
+ * @param path path of a file within the resource directory
+ */
+export function getResourceNameFromPath(filePath: string): string {
+    const paths = filePath                    
+        .replace("/", "\\")
+        .split("\\");
+    
+    for (let i = paths.length - 1; i > 0; i--) {
+
+        // Folders surrounded by square brackets are invalid
+        if (paths[i].startsWith("[") && paths[i].endsWith("]"))
+            continue;
+
+        if (fs.existsSync(paths.slice(0, i + 1).join("\\") + "\\meta.xml")) {
+            console.timeEnd("forexec");
+            return paths[i];
+        }
+    }
+
+    return;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,6 @@ export function getResourceNameFromPath(filePath: string): string {
             continue;
 
         if (fs.existsSync(paths.slice(0, i + 1).join("\\") + "\\meta.xml")) {
-            console.timeEnd("forexec");
             return paths[i];
         }
     }


### PR DESCRIPTION
Not everytime the immediate parent folder is the resources' name. Thus, depending on the structure of the project the resource won't be reloaded properly on file change.

Finding the resource's name from the absolute path it's kinda tricky to do since we don't know the resource root directory. This implementation searches for the first directory with no surrounding square brackets relative to the last `deathmatch\resources` directory.

The only problem is when one creates the `deathmatch\resources` into their resources:
```
├ resources
  ├ myresource
    ├ deathmatch
      ├ resources
      └ # Anything else
    ├ script.lua
    └ meta.xml
```
When editing the `script.lua` it should reload `myresource`, but the last `deathmatch\resources` matches the one inside `myresource`.

I don't know why someone would like to do this, but this can easily be considered a mistake and show an error message.